### PR TITLE
update to ipad bg image fix

### DIFF
--- a/js/utilities/ipad-bg-fix.js
+++ b/js/utilities/ipad-bg-fix.js
@@ -47,7 +47,9 @@ function ipadFix() {
 }
 
 function checkUserAgent() {
-    if((navigator.maxTouchPoints > 0) || (navigator.msMaxTouchPoints > 0)) {
+    if((navigator.maxTouchPoints > 0) || (navigator.msMaxTouchPoints > 0) || (navigator.maxTouchPoints > 2)) {
+        return true;
+    } else if (/iPad/i.test(navigator.userAgent)){
         return true;
     } else {
         return false;


### PR DESCRIPTION
more detection added. Older generations & landscape did not pick up on the script fix. now it should